### PR TITLE
Add foreground service permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
         android:label="HA Notifier"


### PR DESCRIPTION
## Summary
- add the FOREGROUND_SERVICE_DATA_SYNC permission so the foreground WebSocket service can launch on Android 14+

## Testing
- ./gradlew assembleDebug *(fails: gradlew wrapper not included in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdd4cf5cc833090252bc68656f0a7