### PR TITLE
Fix Gradle build script syntax

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,100 +3,95 @@ plugins {
   id 'org.jetbrains.kotlin.android'
   id 'kotlin-kapt'
 }
- 
- android {
-   namespace 'com.example.hanotifier'
-   compileSdk 34
- 
-   defaultConfig {
-     applicationId 'com.example.hanotifier'
-     minSdk 24
-     targetSdk 34
-     versionCode 1
-     versionName '1.0.0'
-   }
- 
-   // ✅ Alinhar o Java para 17
-   compileOptions {
-     sourceCompatibility JavaVersion.VERSION_17
-     targetCompatibility JavaVersion.VERSION_17
-   }
- 
-   // ✅ Alinhar o Kotlin para 17
-   kotlinOptions {
-     jvmTarget = '17'
-     freeCompilerArgs += ['-Xjvm-default=all']
-   }
- 
--  // ✅ Forçar toolchain 17 (evita inconsistências no CI)
-+  // ✅ Alinhar com a JDK 21 disponível no ambiente de build
-   kotlin {
--    jvmToolchain(17)
-+    jvmToolchain(21)
-   }
- 
-   // Signing antes de buildTypes (condicional)
-   signingConfigs {
-     create("release") {
-       def storeFilePath = System.getenv("STORE_FILE") ?: (project.findProperty("STORE_FILE") ?: "")
-       if (storeFilePath?.trim()) {
-         storeFile file(storeFilePath)
-         storePassword System.getenv("STORE_PASSWORD") ?: (project.findProperty("STORE_PASSWORD") ?: "")
-         keyAlias      System.getenv("KEY_ALIAS")      ?: (project.findProperty("KEY_ALIAS")      ?: "")
-         keyPassword   System.getenv("KEY_PASSWORD")   ?: (project.findProperty("KEY_PASSWORD")   ?: "")
-       }
-     }
-   }
- 
-   buildTypes {
-     debug {
-       applicationIdSuffix ".debug"
-     }
-     release {
-       minifyEnabled true
-       shrinkResources true
-       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-       if (signingConfigs.findByName("release")?.storeFile != null) {
-         signingConfig signingConfigs.getByName("release")
-       }
-     }
-   }
- 
-   buildFeatures { compose true }
-   composeOptions { kotlinCompilerExtensionVersion '1.5.14' }
- 
-   packagingOptions {
-     resources { excludes += ['/META-INF/{AL2.0,LGPL2.1}'] }
-   }
- }
- 
- dependencies {
-   implementation platform('androidx.compose:compose-bom:2024.08.00')
-   implementation 'androidx.compose.ui:ui'
-   implementation 'androidx.compose.material3:material3'
-   implementation 'androidx.compose.ui:ui-tooling-preview'
-   debugImplementation 'androidx.compose.ui:ui-tooling'
-   implementation 'androidx.activity:activity-compose:1.9.2'
-   implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.4'
-+  implementation 'androidx.lifecycle:lifecycle-service:2.8.4'
-   implementation 'androidx.navigation:navigation-compose:2.8.0'
- 
-   implementation 'com.google.android.material:material:1.12.0'
- 
-+  implementation 'androidx.compose.material:material-icons-extended'
-+  implementation 'androidx.compose.foundation:foundation'
-+
-   implementation 'androidx.datastore:datastore-preferences:1.1.1'
- 
-   implementation 'androidx.room:room-ktx:2.6.1'
-   kapt 'androidx.room:room-compiler:2.6.1'
- 
-   implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-   implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
- 
-   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
-   implementation 'androidx.work:work-runtime-ktx:2.9.1'
- }
- 
-EOF
-)
+
+android {
+  namespace 'com.example.hanotifier'
+  compileSdk 34
+
+  defaultConfig {
+    applicationId 'com.example.hanotifier'
+    minSdk 24
+    targetSdk 34
+    versionCode 1
+    versionName '1.0.0'
+  }
+
+  // ✅ Alinhar o Java para 17
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
+
+  // ✅ Alinhar o Kotlin para 17
+  kotlinOptions {
+    jvmTarget = '17'
+    freeCompilerArgs += ['-Xjvm-default=all']
+  }
+
+  // ✅ Alinhar com a JDK 21 disponível no ambiente de build
+  kotlin {
+    jvmToolchain(21)
+  }
+
+  // Signing antes de buildTypes (condicional)
+  signingConfigs {
+    create("release") {
+      def storeFilePath = System.getenv("STORE_FILE") ?: (project.findProperty("STORE_FILE") ?: "")
+      if (storeFilePath?.trim()) {
+        storeFile file(storeFilePath)
+        storePassword System.getenv("STORE_PASSWORD") ?: (project.findProperty("STORE_PASSWORD") ?: "")
+        keyAlias      System.getenv("KEY_ALIAS")      ?: (project.findProperty("KEY_ALIAS")      ?: "")
+        keyPassword   System.getenv("KEY_PASSWORD")   ?: (project.findProperty("KEY_PASSWORD")   ?: "")
+      }
+    }
+  }
+
+  buildTypes {
+    debug {
+      applicationIdSuffix ".debug"
+    }
+    release {
+      minifyEnabled true
+      shrinkResources true
+      proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+      if (signingConfigs.findByName("release")?.storeFile != null) {
+        signingConfig signingConfigs.getByName("release")
+      }
+    }
+  }
+
+  buildFeatures { compose true }
+  composeOptions { kotlinCompilerExtensionVersion '1.5.14' }
+
+  packagingOptions {
+    resources { excludes += ['/META-INF/{AL2.0,LGPL2.1}'] }
+  }
+}
+
+dependencies {
+  implementation platform('androidx.compose:compose-bom:2024.08.00')
+  implementation 'androidx.compose.ui:ui'
+  implementation 'androidx.compose.material3:material3'
+  implementation 'androidx.compose.ui:ui-tooling-preview'
+  debugImplementation 'androidx.compose.ui:ui-tooling'
+  implementation 'androidx.activity:activity-compose:1.9.2'
+  implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.4'
+  implementation 'androidx.lifecycle:lifecycle-service:2.8.4'
+  implementation 'androidx.navigation:navigation-compose:2.8.0'
+
+  implementation 'com.google.android.material:material:1.12.0'
+
+  implementation 'androidx.compose.material:material-icons-extended'
+  implementation 'androidx.compose.foundation:foundation'
+
+  implementation 'androidx.datastore:datastore-preferences:1.1.1'
+
+  implementation 'androidx.room:room-ktx:2.6.1'
+  kapt 'androidx.room:room-compiler:2.6.1'
+
+  implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+  implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
+
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
+  implementation 'androidx.work:work-runtime-ktx:2.9.1'
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
         android:label="HA Notifier"


### PR DESCRIPTION
## Summary
- add the FOREGROUND_SERVICE_DATA_SYNC permission so the foreground WebSocket service can launch on Android 14+
- repair the Gradle build script that had leftover diff markers so the project configuration loads correctly

## Testing
- gradle --no-daemon assembleDebug *(fails: Android SDK not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdd4cf5cc833090252bc68656f0a7