### PR TITLE
Add foreground service permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application


### PR DESCRIPTION
## Summary
- add the generic foreground service permission alongside existing runtime permissions so the service can start

## Testing
- `./gradlew assembleDebug` *(fails: ./gradlew: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe20fc9dc833080e20bf9b2cff2f8