### PR TITLE
Support rich notification popups and actions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,4 +94,6 @@ dependencies {
 
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1'
   implementation 'androidx.work:work-runtime-ktx:2.9.1'
+
+  implementation 'io.coil-kt:coil-compose:2.6.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
@@ -28,6 +30,10 @@
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
+
+        <receiver
+            android:name=".notify.ActionReceiver"
+            android:exported="false" />
 
         <activity
             android:name=".notify.AlertActivity"

--- a/app/src/main/java/com/example/hanotifier/data/Payload.kt
+++ b/app/src/main/java/com/example/hanotifier/data/Payload.kt
@@ -1,12 +1,14 @@
 package com.example.hanotifier.data
 
+import java.io.Serializable
+
 data class Action(
   val title: String,
   val type: String? = null, // "ha_service" | "url"
   val service: String? = null,
   val entity_id: String? = null,
   val url: String? = null,
-)
+) : Serializable
 
 data class Payload(
   val title: String,

--- a/app/src/main/java/com/example/hanotifier/notify/ActionExecutor.kt
+++ b/app/src/main/java/com/example/hanotifier/notify/ActionExecutor.kt
@@ -1,0 +1,129 @@
+package com.example.hanotifier.notify
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import com.example.hanotifier.R
+import com.example.hanotifier.data.Prefs
+import com.example.hanotifier.net.HaRest
+import com.example.hanotifier.data.Action as PayloadAction
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+object ActionExecutor {
+
+  data class Result(val success: Boolean, val message: String? = null)
+
+  private const val TAG = "ActionExecutor"
+
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+  fun execute(context: Context, action: PayloadAction, onResult: ((Result) -> Unit)? = null) {
+    val appCtx = context.applicationContext
+    val kind = action.type?.lowercase() ?: when {
+      !action.service.isNullOrBlank() -> "ha_service"
+      !action.url.isNullOrBlank() -> "url"
+      else -> null
+    }
+    when (kind) {
+      "ha_service" -> triggerService(appCtx, action, onResult)
+      "url" -> openUrl(appCtx, action.url, onResult)
+      else -> postResult(appCtx, onResult, Result(false, appCtx.getString(R.string.action_missing_target)))
+    }
+  }
+
+  fun openLink(context: Context, url: String, onResult: ((Result) -> Unit)? = null) {
+    openUrl(context.applicationContext, url, onResult)
+  }
+
+  private fun openUrl(context: Context, rawUrl: String?, onResult: ((Result) -> Unit)?) {
+    val normalized = normalizeUrl(rawUrl)
+    if (normalized == null) {
+      postResult(context, onResult, Result(false, context.getString(R.string.action_link_error)))
+      return
+    }
+    try {
+      val intent = Intent(Intent.ACTION_VIEW, normalized).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      }
+      context.startActivity(intent)
+      postResult(context, onResult, Result(true))
+    } catch (t: Throwable) {
+      Log.w(TAG, "Failed to open link", t)
+      postResult(context, onResult, Result(false, context.getString(R.string.action_link_error)))
+    }
+  }
+
+  private fun triggerService(context: Context, action: PayloadAction, onResult: ((Result) -> Unit)?) {
+    scope.launch {
+      val result = callService(context, action)
+      postResult(context, onResult, result)
+    }
+  }
+
+  private suspend fun callService(context: Context, action: PayloadAction): Result {
+    val serviceName = action.service?.takeIf { it.isNotBlank() }
+      ?: return Result(false, context.getString(R.string.action_missing_service))
+    val parts = serviceName.split('.', limit = 2)
+    if (parts.size != 2) {
+      return Result(false, context.getString(R.string.action_invalid_service))
+    }
+    val (domain, service) = parts
+
+    val prefs = Prefs(context)
+    val baseUrl = withContext(Dispatchers.IO) {
+      prefs.lanUrl.firstOrNull()?.takeIf { it.isNotBlank() }
+        ?: prefs.wanUrl.firstOrNull()?.takeIf { it.isNotBlank() }
+    } ?: return Result(false, context.getString(R.string.action_missing_url))
+
+    val token = withContext(Dispatchers.IO) {
+      prefs.token.firstOrNull()?.takeIf { it.isNotBlank() }
+    } ?: return Result(false, context.getString(R.string.action_missing_token))
+
+    val body = JSONObject().apply {
+      action.entity_id?.takeIf { it.isNotBlank() }?.let { put("entity_id", it) }
+    }.toString()
+
+    return try {
+      HaRest(baseUrl, token).callService(domain, service, body).use { resp ->
+        if (resp.isSuccessful) {
+          Result(true, context.getString(R.string.action_sent))
+        } else {
+          Result(false, context.getString(R.string.action_failed_code, resp.code))
+        }
+      }
+    } catch (t: Throwable) {
+      Log.e(TAG, "Failed to call service", t)
+      Result(false, context.getString(R.string.action_failed_generic))
+    }
+  }
+
+  private fun normalizeUrl(raw: String?): Uri? {
+    val trimmed = raw?.trim().orEmpty()
+    if (trimmed.isBlank()) return null
+    val prefixed = if (Uri.parse(trimmed).scheme.isNullOrBlank()) {
+      "https://$trimmed"
+    } else {
+      trimmed
+    }
+    return runCatching { Uri.parse(prefixed) }.getOrNull()
+  }
+
+  private fun postResult(context: Context, onResult: ((Result) -> Unit)?, result: Result) {
+    Handler(Looper.getMainLooper()).post {
+      onResult?.invoke(result)
+      result.message?.let {
+        Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/example/hanotifier/notify/ActionReceiver.kt
+++ b/app/src/main/java/com/example/hanotifier/notify/ActionReceiver.kt
@@ -1,0 +1,31 @@
+package com.example.hanotifier.notify
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationManagerCompat
+import com.example.hanotifier.data.Action as PayloadAction
+
+class ActionReceiver : BroadcastReceiver() {
+
+  companion object {
+    const val EXTRA_ACTION = "com.example.hanotifier.extra.ACTION"
+    const val EXTRA_NOTIFICATION_ID = "com.example.hanotifier.extra.NOTIFICATION_ID"
+  }
+
+  override fun onReceive(context: Context, intent: Intent) {
+    val pendingResult = goAsync()
+    val action = intent.getSerializableExtra(EXTRA_ACTION) as? PayloadAction
+    if (action == null) {
+      pendingResult.finish()
+      return
+    }
+    val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0)
+    ActionExecutor.execute(context.applicationContext, action) { result ->
+      if (result.success && notificationId != 0) {
+        NotificationManagerCompat.from(context).cancel(notificationId)
+      }
+      pendingResult.finish()
+    }
+  }
+}

--- a/app/src/main/java/com/example/hanotifier/notify/AlertActivity.kt
+++ b/app/src/main/java/com/example/hanotifier/notify/AlertActivity.kt
@@ -1,43 +1,211 @@
 package com.example.hanotifier.notify
 
 import android.os.Bundle
+import android.util.Patterns
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.core.app.NotificationManagerCompat
+import coil.compose.AsyncImage
+import com.example.hanotifier.data.Action as NotificationAction
 import com.example.hanotifier.ui.theme.AppTheme
+import java.util.ArrayList
 
-class AlertActivity: ComponentActivity() {
+class AlertActivity : ComponentActivity() {
+
+  companion object {
+    const val EXTRA_TITLE = "com.example.hanotifier.extra.TITLE"
+    const val EXTRA_BODY = "com.example.hanotifier.extra.BODY"
+    const val EXTRA_IMAGE = "com.example.hanotifier.extra.IMAGE"
+    const val EXTRA_ACTIONS = "com.example.hanotifier.extra.ACTIONS"
+    const val EXTRA_NOTIFICATION_ID = "com.example.hanotifier.extra.NOTIFICATION_ID"
+  }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     window.addFlags(
       WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
-      WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+        WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
     )
-    val title = intent.getStringExtra("title") ?: "Alerta"
-    val body = intent.getStringExtra("body") ?: ""
-    setContent { AppTheme { AlertContent(title, body) } }
+
+    val title = intent.getStringExtra(EXTRA_TITLE) ?: "Alerta"
+    val body = intent.getStringExtra(EXTRA_BODY) ?: ""
+    val image = intent.getStringExtra(EXTRA_IMAGE)
+    @Suppress("UNCHECKED_CAST")
+    val actions = (intent.getSerializableExtra(EXTRA_ACTIONS) as? ArrayList<NotificationAction>)?.toList().orEmpty()
+    val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, 0)
+    val appContext = applicationContext
+    val activity = this
+
+    setContent {
+      AppTheme {
+        AlertContent(
+          title = title,
+          body = body,
+          image = image,
+          actions = actions,
+          onAction = { action ->
+            ActionExecutor.execute(appContext, action) { result ->
+              if (result.success) {
+                if (notificationId != 0) {
+                  NotificationManagerCompat.from(activity).cancel(notificationId)
+                }
+                activity.finish()
+              }
+            }
+          },
+          onLink = { url ->
+            ActionExecutor.openLink(appContext, url) { result ->
+              if (result.success) {
+                if (notificationId != 0) {
+                  NotificationManagerCompat.from(activity).cancel(notificationId)
+                }
+                activity.finish()
+              }
+            }
+          },
+          onAck = {
+            if (notificationId != 0) {
+              NotificationManagerCompat.from(activity).cancel(notificationId)
+            }
+            activity.finish()
+          }
+        )
+      }
+    }
   }
 }
 
 @Composable
-private fun AlertContent(title: String, body: String) {
-  Surface {
+private fun AlertContent(
+  title: String,
+  body: String,
+  image: String?,
+  actions: List<NotificationAction>,
+  onAction: (NotificationAction) -> Unit,
+  onLink: (String) -> Unit,
+  onAck: () -> Unit,
+) {
+  val linkColor = MaterialTheme.colorScheme.primary
+  val annotatedBody = remember(body, linkColor) {
+    val matcher = Patterns.WEB_URL.matcher(body)
+    if (!matcher.find()) {
+      AnnotatedString(body)
+    } else {
+      matcher.reset()
+      buildAnnotatedString {
+        var lastIndex = 0
+        while (matcher.find()) {
+          val start = matcher.start()
+          val end = matcher.end()
+          append(body.substring(lastIndex, start))
+          val url = matcher.group()
+          val normalized = if (url.startsWith("http", true)) url else "https://$url"
+          pushStringAnnotation(tag = "link", annotation = normalized)
+          withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) {
+            append(url)
+          }
+          pop()
+          lastIndex = end
+        }
+        append(body.substring(lastIndex))
+      }
+    }
+  }
+
+  Surface(color = MaterialTheme.colorScheme.scrim.copy(alpha = 0.45f)) {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-      Card(modifier = Modifier.padding(24.dp)) {
-        Column(Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-          Text(title, style = MaterialTheme.typography.titleLarge)
-          Text(body)
-          Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            val ctx = LocalContext.current
-            Button(onClick = { /* TODO: executar ação HA se necessário */ }) { Text("Ação") }
-            OutlinedButton(onClick = { (ctx as? ComponentActivity)?.finish() }) { Text("Reconhecer") }
+      Card(
+        modifier = Modifier
+          .padding(24.dp)
+          .fillMaxWidth(0.92f)
+          .widthIn(max = 480.dp),
+        shape = RoundedCornerShape(20.dp)
+      ) {
+        val scrollState = rememberScrollState()
+        Column(
+          modifier = Modifier
+            .padding(24.dp)
+            .verticalScroll(scrollState),
+          verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+          Text(title, style = MaterialTheme.typography.headlineSmall)
+          if (body.isNotBlank()) {
+            ClickableText(
+              text = annotatedBody,
+              style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+              onClick = { offset ->
+                annotatedBody.getStringAnnotations("link", offset, offset).firstOrNull()?.let { onLink(it.item) }
+              }
+            )
+          }
+          image?.takeIf { it.isNotBlank() }?.let { model ->
+            AsyncImage(
+              model = model,
+              contentDescription = null,
+              contentScale = ContentScale.Crop,
+              modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 240.dp)
+                .clip(RoundedCornerShape(16.dp))
+            )
+          }
+          if (actions.isNotEmpty()) {
+            Divider()
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+              actions.forEachIndexed { index, action ->
+                val buttonModifier = Modifier.fillMaxWidth()
+                if (index == 0) {
+                  Button(modifier = buttonModifier, onClick = { onAction(action) }) {
+                    Text(action.title)
+                  }
+                } else {
+                  OutlinedButton(modifier = buttonModifier, onClick = { onAction(action) }) {
+                    Text(action.title)
+                  }
+                }
+              }
+            }
+          }
+          Spacer(modifier = Modifier.heightIn(min = 4.dp))
+          Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+          ) {
+            OutlinedButton(onClick = onAck) { Text("Reconhecer") }
           }
         }
       }

--- a/app/src/main/java/com/example/hanotifier/notify/NotificationHelper.kt
+++ b/app/src/main/java/com/example/hanotifier/notify/NotificationHelper.kt
@@ -8,18 +8,30 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
 import android.os.Build
+import android.util.Base64
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import com.example.hanotifier.R
 import com.example.hanotifier.data.*
 import kotlinx.coroutines.*
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.ArrayList
 
 object NotificationHelper {
   const val CH_INFO = "info"
   const val CH_WARN = "warning"
   const val CH_CRIT = "critical"
+
+  private const val TAG = "NotificationHelper"
+
+  private val imageClient by lazy { OkHttpClient() }
 
   fun canPostNotifications(ctx: Context): Boolean {
     val notificationsEnabled = NotificationManagerCompat.from(ctx).areNotificationsEnabled()
@@ -69,29 +81,122 @@ object NotificationHelper {
     CoroutineScope(Dispatchers.Default).launch {
       val tpl = resolveTemplate(ctx, payload)
       val (priority, persistent, popup) = merged(payload, tpl)
+      val actions = payload.actions ?: emptyList()
+      val notificationId = payload.collapseKey.hashCode()
+      val pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT or (
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+      )
 
-      val channel = when(priority) { "critical" -> CH_CRIT; "warning" -> CH_WARN; else -> CH_INFO }
+      val alertIntent = Intent(ctx, AlertActivity::class.java).apply {
+        putExtra(AlertActivity.EXTRA_TITLE, payload.title)
+        putExtra(AlertActivity.EXTRA_BODY, payload.body)
+        putExtra(AlertActivity.EXTRA_IMAGE, payload.image)
+        putExtra(AlertActivity.EXTRA_ACTIONS, ArrayList(actions))
+        putExtra(AlertActivity.EXTRA_NOTIFICATION_ID, notificationId)
+      }
+      val alertPI = PendingIntent.getActivity(ctx, notificationId, alertIntent, pendingFlags)
 
-      val fullIntent = Intent(ctx, AlertActivity::class.java).putExtra("title", payload.title).putExtra("body", payload.body)
-      val fullPI = PendingIntent.getActivity(ctx, 0, fullIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+      val imageBitmap = payload.image?.let { loadBitmap(ctx, it) }
 
-      val b = NotificationCompat.Builder(ctx, channel)
+      val channel = when (priority) {
+        "critical" -> CH_CRIT
+        "warning" -> CH_WARN
+        else -> CH_INFO
+      }
+
+      val builder = NotificationCompat.Builder(ctx, channel)
         .setSmallIcon(R.mipmap.ic_launcher)
         .setContentTitle(payload.title)
         .setContentText(payload.body)
-        .setStyle(NotificationCompat.BigTextStyle().bigText(payload.body))
         .setPriority(NotificationCompat.PRIORITY_MAX)
         .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
         .setOngoing(persistent)
         .setAutoCancel(!persistent)
+        .setContentIntent(alertPI)
 
-      if (priority == "critical" && (popup)) {
-        b.setCategory(Notification.CATEGORY_ALARM)
-        b.setFullScreenIntent(fullPI, true)
-        b.setOngoing(true) // fallback persistente
+      if (imageBitmap != null) {
+        builder.setLargeIcon(imageBitmap)
+        builder.setStyle(
+          NotificationCompat.BigPictureStyle()
+            .bigPicture(imageBitmap)
+            .setSummaryText(payload.body)
+        )
+      } else {
+        builder.setStyle(NotificationCompat.BigTextStyle().bigText(payload.body))
       }
 
-      NotificationManagerCompat.from(ctx).notify(payload.collapseKey.hashCode(), b.build())
+      actions.forEachIndexed { index, action ->
+        val actionIntent = Intent(ctx, ActionReceiver::class.java).apply {
+          putExtra(ActionReceiver.EXTRA_ACTION, action)
+          putExtra(ActionReceiver.EXTRA_NOTIFICATION_ID, notificationId)
+        }
+        val actionPI = PendingIntent.getBroadcast(
+          ctx,
+          notificationId + index + 1,
+          actionIntent,
+          pendingFlags
+        )
+        builder.addAction(actionIcon(action), action.title, actionPI)
+      }
+
+      if (priority == "critical" && popup) {
+        builder.setCategory(Notification.CATEGORY_ALARM)
+        builder.setFullScreenIntent(alertPI, true)
+        builder.setOngoing(true) // fallback persistente
+      }
+
+      NotificationManagerCompat.from(ctx).notify(notificationId, builder.build())
+    }
+  }
+
+  private fun actionIcon(action: Action): Int {
+    return when (action.type?.lowercase()) {
+      "url" -> android.R.drawable.ic_menu_view
+      "ha_service" -> android.R.drawable.ic_media_play
+      else -> android.R.drawable.ic_menu_send
+    }
+  }
+
+  private suspend fun loadBitmap(ctx: Context, ref: String): Bitmap? = withContext(Dispatchers.IO) {
+    try {
+      val uri = runCatching { Uri.parse(ref) }.getOrNull()
+      when (uri?.scheme?.lowercase()) {
+        "http", "https" -> fetchRemoteBitmap(uri.toString())
+        "data" -> decodeDataUri(ref)
+        "file" -> uri.path?.let { BitmapFactory.decodeFile(it) }
+        "content" -> ctx.contentResolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it) }
+        else -> if (ref.startsWith('/')) BitmapFactory.decodeFile(ref) else null
+      }
+    } catch (t: Throwable) {
+      Log.w(TAG, "Failed to load notification image", t)
+      null
+    }
+  }
+
+  private fun decodeDataUri(data: String): Bitmap? {
+    val comma = data.indexOf(',')
+    if (comma <= 0) return null
+    return try {
+      val base64 = data.substring(comma + 1)
+      val bytes = Base64.decode(base64, Base64.DEFAULT)
+      BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    } catch (t: Throwable) {
+      Log.w(TAG, "Failed to decode inline image", t)
+      null
+    }
+  }
+
+  private fun fetchRemoteBitmap(url: String): Bitmap? {
+    return try {
+      val request = Request.Builder().url(url).build()
+      imageClient.newCall(request).execute().use { resp ->
+        if (!resp.isSuccessful) return null
+        val bytes = resp.body?.bytes() ?: return null
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+      }
+    } catch (t: Throwable) {
+      Log.w(TAG, "Failed to download notification image", t)
+      null
     }
   }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,13 @@
     <string name="settings">Definições</string>
     <string name="home">Início</string>
     <string name="test_notification">Notificação de teste</string>
+    <string name="action_missing_target">Ação sem destino</string>
+    <string name="action_link_error">Não foi possível abrir o link</string>
+    <string name="action_missing_service">Serviço em falta</string>
+    <string name="action_invalid_service">Serviço inválido</string>
+    <string name="action_missing_url">URL do Home Assistant em falta</string>
+    <string name="action_missing_token">Token do Home Assistant em falta</string>
+    <string name="action_sent">Ação enviada</string>
+    <string name="action_failed_code">Falha ao executar ação (%1$d)</string>
+    <string name="action_failed_generic">Erro ao contactar o Home Assistant</string>
 </resources>


### PR DESCRIPTION
## Summary
- add an action execution pipeline and broadcast receiver so notification buttons can open links or trigger Home Assistant services
- enhance NotificationHelper to attach actions, propagate payload metadata to the popup, and render images with BigPicture styling
- redesign the AlertActivity full-screen popup to show media, clickable links, and action buttons and add the Coil dependency plus user-facing strings

## Testing
- ./gradlew lint *(fails: Gradle wrapper not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d01660a4608330a8df8645cdf35834